### PR TITLE
Fix build failures caused by font downloads and route handler types

### DIFF
--- a/src/app/api/budgets/[id]/route.ts
+++ b/src/app/api/budgets/[id]/route.ts
@@ -5,12 +5,16 @@ interface Params {
   id: string;
 }
 
+type RouteContext = {
+  params: Promise<Params>;
+};
+
 export async function GET(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
 
     const budget = await prisma.teacherBudget.findUnique({
       where: { id },
@@ -62,10 +66,10 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
     const body = await request.json();
     const {
       minutesWeekly,
@@ -155,10 +159,10 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
 
     // Verifica se il budget esiste
     const existingBudget = await prisma.teacherBudget.findUnique({

--- a/src/app/api/recovery-types/[id]/route.ts
+++ b/src/app/api/recovery-types/[id]/route.ts
@@ -5,12 +5,16 @@ interface Params {
   id: string;
 }
 
+type RouteContext = {
+  params: Promise<Params>;
+};
+
 export async function GET(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
 
     const recoveryType = await prisma.recoveryType.findUnique({
       where: { id },
@@ -63,10 +67,10 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
     const body = await request.json();
     const {
       name,
@@ -152,10 +156,10 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: Params }
+  context: RouteContext
 ) {
   try {
-    const { id } = params;
+    const { id } = await context.params;
 
     // Verifica se la tipologia esiste
     const existingType = await prisma.recoveryType.findUnique({

--- a/src/app/api/teachers/route.ts
+++ b/src/app/api/teachers/route.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
-
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,8 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+    --font-geist-sans: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+    --font-geist-mono: "Menlo", "Fira Code", "SFMono-Regular", monospace;
   }
 
   .dark {
@@ -89,6 +91,7 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: "rlig" 1, "calt" 1;
+    font-family: var(--font-sans);
   }
   
   /* Scrollbar styles */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from '@/components/providers/theme-provider'
 import { AuthProvider } from '@/components/auth/auth-provider'
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Sistema Tracking Recuperi",
@@ -26,9 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="it" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="font-sans antialiased">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/layout/main-layout.tsx
+++ b/src/components/layout/main-layout.tsx
@@ -25,18 +25,17 @@ export function MainLayout({
   return (
     <div className="min-h-screen bg-background flex">
       {/* Sidebar */}
-      <Sidebar 
-        open={sidebarOpen} 
-        onOpenChange={setSidebarOpen}
+      <Sidebar
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
         className="hidden lg:flex"
       />
-      
+
       {/* Mobile sidebar overlay */}
-      <Sidebar 
-        open={sidebarOpen} 
-        onOpenChange={setSidebarOpen}
+      <Sidebar
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
         className="lg:hidden"
-        mobile
       />
 
       {/* Main content */}


### PR DESCRIPTION
## Summary
- replace the `next/font` google imports with CSS-based font fallbacks so the build no longer depends on downloading Geist from Google Fonts
- update API route handlers to use the new RouteContext signature and remove the unused Supabase service client to prevent build-time env errors
- align the main layout sidebar usage with the Sidebar component props

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d935da08d08327a8a5d884c6a444b6